### PR TITLE
[Silabs][Wi-Fi] Added Implementation for timeouts waiting for a TX Confirmation Event BLE

### DIFF
--- a/src/platform/silabs/BLEManagerImpl.h
+++ b/src/platform/silabs/BLEManagerImpl.h
@@ -198,6 +198,9 @@ private:
 
 #if (SLI_SI91X_ENABLE_BLE || RSI_BLE_ENABLE)
     void HandleRXCharWrite(rsi_ble_event_write_t * evt);
+    void StartBleSendIndicationTimeoutTimer(uint32_t aTimeoutInMs);
+    void CancelBleSendIndicationTimeoutTimer(void);
+    static void BleSendIndicationTimeoutHandler(TimerHandle_t xTimer);
 #else
     void HandleRXCharWrite(volatile sl_bt_msg_t * evt);
 #endif
@@ -209,12 +212,6 @@ private:
     static void DriveBLEState(intptr_t arg);
     static void BleAdvTimeoutHandler(TimerHandle_t xTimer);
     uint8_t GetTimerHandle(uint8_t connectionHandle, bool allocate);
-
-
- #if (SLI_SI91X_ENABLE_BLE || RSI_BLE_ENABLE)   
-    protected:
-    static void OnSendIndicationTimeout(System::Layer * aLayer, void * appState);
-#endif
 };
 
 /**

--- a/src/platform/silabs/BLEManagerImpl.h
+++ b/src/platform/silabs/BLEManagerImpl.h
@@ -209,6 +209,12 @@ private:
     static void DriveBLEState(intptr_t arg);
     static void BleAdvTimeoutHandler(TimerHandle_t xTimer);
     uint8_t GetTimerHandle(uint8_t connectionHandle, bool allocate);
+
+
+ #if (SLI_SI91X_ENABLE_BLE || RSI_BLE_ENABLE)   
+    protected:
+    static void OnSendIndicationTimeout(System::Layer * aLayer, void * appState);
+#endif
 };
 
 /**

--- a/src/platform/silabs/BLEManagerImpl.h
+++ b/src/platform/silabs/BLEManagerImpl.h
@@ -30,6 +30,8 @@
 #define BLE_MAX_CONNECTION_INTERVAL_MS 45 // 45 msec
 #define BLE_SLAVE_LATENCY_MS 0
 #define BLE_TIMEOUT_MS 400
+#define BLE_DEFAULT_TIMER_PERIOD_MS (1)
+#define BLE_SEND_INDICATION_TIMER_PERIOD_MS (400) // Time kept to support all WiFi chips BLE (RS9116/ SiWx917 NCP/SOC)
 #endif // (SLI_SI91X_ENABLE_BLE || RSI_BLE_ENABLE)
 #include "FreeRTOS.h"
 #include "timers.h"

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -246,9 +246,6 @@ namespace {
 #define BLE_CONFIG_MIN_CE_LENGTH (0)      // Leave to min value
 #define BLE_CONFIG_MAX_CE_LENGTH (0xFFFF) // Leave to max value
 
-#define BLE_DEFAULT_TIMER_PERIOD_MS (1)
-#define BLE_SEND_INDICATION_TIMER_PERIOD_MS (400) // Time kept to support all WiFi chips BLE (RS9116/ SiWx917 NCP/SOC)
-
 TimerHandle_t sbleAdvTimeoutTimer; // FreeRTOS sw timer.
 TimerHandle_t sbleSendIndicationTimeoutTimer; // FreeRTOS sw timer.
 

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -247,7 +247,7 @@ namespace {
 #define BLE_CONFIG_MAX_CE_LENGTH (0xFFFF) // Leave to max value
 
 #define BLE_DEFAULT_TIMER_PERIOD_MS (1)
-#define BLE_SEND_INDICATION_TIMER_PERIOD_MS (400)
+#define BLE_SEND_INDICATION_TIMER_PERIOD_MS (500) // Time kept to support all WiFi chips BLE (RS9116/ SiWx917 NCP/SOC)
 
 TimerHandle_t sbleAdvTimeoutTimer; // FreeRTOS sw timer.
 TimerHandle_t sbleSendIndicationTimeoutTimer; // FreeRTOS sw timer.
@@ -481,9 +481,7 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUU
     status = rsi_ble_indicate_value(event_msg.resp_enh_conn.dev_addr, event_msg.rsi_ble_measurement_hndl, (data->DataLength()),
                                     data->Start());
     
-    ChipLogProgress(DeviceLayer, "StartTimer start");
     StartBleSendIndicationTimeoutTimer(BLE_SEND_INDICATION_TIMER_PERIOD_MS);
-    ChipLogProgress(DeviceLayer, "StartTimer Stop");
 
     if (status != RSI_SUCCESS)
     {
@@ -951,7 +949,6 @@ void BLEManagerImpl::HandleSoftTimerEvent(void)
     event.Type                                                   = DeviceEventType::kCHIPoBLEConnectionError;
     event.CHIPoBLEConnectionError.ConId                          = connHandle;
     event.CHIPoBLEConnectionError.Reason                         = BLE_ERROR_CHIPOBLE_PROTOCOL_ABORT;
-    ChipLogProgress(DeviceLayer, "BLEManagerImpl::HandleSoftTimerEvent CHIPOBLE_PROTOCOL_ABORT");
     PlatformMgr().PostEventOrDie(&event);
 }
 

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -478,7 +478,7 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUU
                                     PacketBufferHandle data)
 {
     int32_t status = 0;
-        status = rsi_ble_indicate_value(event_msg.resp_enh_conn.dev_addr, event_msg.rsi_ble_measurement_hndl, (data->DataLength()),
+    status = rsi_ble_indicate_value(event_msg.resp_enh_conn.dev_addr, event_msg.rsi_ble_measurement_hndl, (data->DataLength()),
                                     data->Start());
     
     ChipLogProgress(DeviceLayer, "StartTimer start");

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -247,7 +247,7 @@ namespace {
 #define BLE_CONFIG_MAX_CE_LENGTH (0xFFFF) // Leave to max value
 
 #define BLE_DEFAULT_TIMER_PERIOD_MS (1)
-#define BLE_SEND_INDICATION_TIMER_PERIOD_MS (10)
+#define BLE_SEND_INDICATION_TIMER_PERIOD_MS (400)
 
 TimerHandle_t sbleAdvTimeoutTimer; // FreeRTOS sw timer.
 TimerHandle_t sbleSendIndicationTimeoutTimer; // FreeRTOS sw timer.
@@ -951,6 +951,7 @@ void BLEManagerImpl::HandleSoftTimerEvent(void)
     event.Type                                                   = DeviceEventType::kCHIPoBLEConnectionError;
     event.CHIPoBLEConnectionError.ConId                          = connHandle;
     event.CHIPoBLEConnectionError.Reason                         = BLE_ERROR_CHIPOBLE_PROTOCOL_ABORT;
+    ChipLogProgress(DeviceLayer, "BLEManagerImpl::HandleSoftTimerEvent CHIPOBLE_PROTOCOL_ABORT");
     PlatformMgr().PostEventOrDie(&event);
 }
 
@@ -1125,6 +1126,7 @@ void BLEManagerImpl::StartBleAdvTimeoutTimer(uint32_t aTimeoutInMs)
 
 void BLEManagerImpl::BleSendIndicationTimeoutHandler(TimerHandle_t xTimer)
 {
+        ChipLogProgress(DeviceLayer, "BleSendIndicationTimeoutHandler::Start");
         sInstance.HandleSoftTimerEvent();
 }
 

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -247,7 +247,7 @@ namespace {
 #define BLE_CONFIG_MAX_CE_LENGTH (0xFFFF) // Leave to max value
 
 #define BLE_DEFAULT_TIMER_PERIOD_MS (1)
-#define BLE_SEND_INDICATION_TIMER_PERIOD_MS (500) // Time kept to support all WiFi chips BLE (RS9116/ SiWx917 NCP/SOC)
+#define BLE_SEND_INDICATION_TIMER_PERIOD_MS (400) // Time kept to support all WiFi chips BLE (RS9116/ SiWx917 NCP/SOC)
 
 TimerHandle_t sbleAdvTimeoutTimer; // FreeRTOS sw timer.
 TimerHandle_t sbleSendIndicationTimeoutTimer; // FreeRTOS sw timer.
@@ -1123,7 +1123,6 @@ void BLEManagerImpl::StartBleAdvTimeoutTimer(uint32_t aTimeoutInMs)
 
 void BLEManagerImpl::BleSendIndicationTimeoutHandler(TimerHandle_t xTimer)
 {
-        ChipLogProgress(DeviceLayer, "BleSendIndicationTimeoutHandler::Start");
         sInstance.HandleSoftTimerEvent();
 }
 
@@ -1145,7 +1144,7 @@ void BLEManagerImpl::StartBleSendIndicationTimeoutTimer(uint32_t aTimeoutInMs)
     // timer is not active, change its period to required value (== restart).
     // FreeRTOS- Block for a maximum of 100 ticks if the change period command
     // cannot immediately be sent to the timer command queue.
-    if (xTimerChangePeriod(sbleSendIndicationTimeoutTimer, pdMS_TO_TICKS(aTimeoutInMs), pdMS_TO_TICKS(100)) != pdPASS)
+    if (xTimerChangePeriod(sbleSendIndicationTimeoutTimer, pdMS_TO_TICKS(aTimeoutInMs), pdMS_TO_TICKS(BLE_CONFIG_TIMEOUT)) != pdPASS)
     {
         ChipLogError(DeviceLayer, "Failed to start BledAdv timeout timer");
     }

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -480,7 +480,7 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUU
                                     data->Start());
     
     // start timer for light indication confirmation. Long delay for spake2 indication
-    DeviceLayer::SystemLayer().StartTimer(Clock::Milliseconds32(BLE_SEND_INDICATION_TIMER_PERIOD_MS), OnSendIndicationTimeout, this);
+    DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(BLE_SEND_INDICATION_TIMER_PERIOD_MS), OnSendIndicationTimeout, this);
 
     if (status != RSI_SUCCESS)
     {
@@ -935,18 +935,18 @@ void BLEManagerImpl::HandleTxConfirmationEvent(BLE_CONNECTION_OBJECT conId)
     ChipDeviceEvent event;
     event.Type                          = DeviceEventType::kCHIPoBLEIndicateConfirm;
     event.CHIPoBLEIndicateConfirm.ConId = conId;
-    DeviceLayer::SystemLayer().CancelTimer(BLEManagerImpl, this);
+    DeviceLayer::SystemLayer().CancelTimer(OnSendIndicationTimeout, this);
     PlatformMgr().PostEventOrDie(&event);
 }
 
 
 void BLEManagerImpl::HandleSoftTimerEvent(void)
 {
+    uint8_t connHandle = 1;
     ChipLogProgress(DeviceLayer, "BLEManagerImpl::HandleSoftTimerEvent CHIPOBLE_PROTOCOL_ABORT");
     ChipDeviceEvent event;
     event.Type                                                   = DeviceEventType::kCHIPoBLEConnectionError;
-    event.CHIPoBLEConnectionError.ConId                          = mIndConfId[evt->data.evt_system_soft_timer.handle];
-    sInstance.mIndConfId[evt->data.evt_system_soft_timer.handle] = kUnusedIndex;
+    event.CHIPoBLEConnectionError.ConId                          = connHandle;
     event.CHIPoBLEConnectionError.Reason                         = BLE_ERROR_CHIPOBLE_PROTOCOL_ABORT;
     PlatformMgr().PostEventOrDie(&event);
 }

--- a/src/platform/silabs/rs911x/BLEManagerImpl.cpp
+++ b/src/platform/silabs/rs911x/BLEManagerImpl.cpp
@@ -299,7 +299,7 @@ CHIP_ERROR BLEManagerImpl::_Init()
                                        pdMS_TO_TICKS(BLE_SEND_INDICATION_TIMER_PERIOD_MS), // == default timer period
                                        false,                                      // no timer reload (==one-shot)
                                        (void *) this,                              // init timer id = ble obj context
-                                       BleAdvTimeoutHandler                        // timer callback handler
+                                       BleSendIndicationTimeoutHandler                        // timer callback handler
     );
 
     mFlags.ClearAll().Set(Flags::kAdvertisingEnabled, CHIP_DEVICE_CONFIG_CHIPOBLE_ENABLE_ADVERTISING_AUTOSTART);


### PR DESCRIPTION
Description of Problem/Feature:
Missing the Implementation for timeouts waiting for a TX Confirmation Event for WiFi BLE

Description of Fix/Solution:
Added Implementation for timeouts waiting for a TX Confirmation Event BLE.

Testing Done:
917 NCP + 4186C
917 SOC+ 4187C
